### PR TITLE
ci: adapt to `master` only workflow on `config` repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,6 @@ jobs:
       name: go/default
       tag: '1.14'
     parameters:
-      branch:
-        type: string
       cluster:
         type: string
       committer_name:
@@ -100,7 +98,7 @@ jobs:
             git config --global user.email "<< parameters.committer_email >>"
       - run:
           name: Cloning config repository
-          command: git clone -b << parameters.branch >> --single-branch git@github.com:triggermesh/config.git tmconfig
+          command: git clone --single-branch git@github.com:triggermesh/config.git tmconfig
       - run:
           name: Updating overlays/<< parameters.cluster >>/channels manifests
           working_directory: tmconfig/
@@ -115,7 +113,7 @@ jobs:
           command: |
             git add overlays
             git commit -m "Update overlays/<< parameters.cluster >>/channels azure-event deployment to '${CIRCLE_TAG:-${CIRCLE_SHA1}}'"
-            git push origin << parameters.branch >>
+            git push origin master
 
   release:
     executor:
@@ -172,7 +170,6 @@ workflows:
               only: master
       - deploy:
           name: update-staging-config
-          branch: dev
           cluster: staging
           requires:
             - publish
@@ -183,7 +180,6 @@ workflows:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
       - deploy:
           name: update-production-config
-          branch: master
           cluster: prod
           requires:
             - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,17 +102,19 @@ jobs:
           name: Cloning config repository
           command: git clone -b << parameters.branch >> --single-branch git@github.com:triggermesh/config.git tmconfig
       - run:
-          name: Updating overlays/<< parameters.cluster >>/channels/azure-event manifests
+          name: Updating overlays/<< parameters.cluster >>/channels manifests
           working_directory: tmconfig/
           command: |
-            sed "s/_IMAGE_TAG_/${CIRCLE_TAG:-${CIRCLE_SHA1}}/g" overlays/<< parameters.cluster >>/channels/azure-event/deployment.yaml.PATTERN > overlays/<< parameters.cluster >>/channels/azure-event/deployment.yaml
+            sed -i overlays/<< parameters.cluster >>/channels/deployments.yaml \
+              -e "s|gcr.io/triggermesh/azure-event-channel-controller:.*|gcr.io/triggermesh/azure-event-channel-controller:"${CIRCLE_TAG:-${CIRCLE_SHA1}}"|g" \
+              -e "s|gcr.io/triggermesh/azure-event-channel-dispatcher:.*|gcr.io/triggermesh/azure-event-channel-dispatcher:"${CIRCLE_TAG:-${CIRCLE_SHA1}}"|g"
             git --no-pager diff
       - run:
-          name: Committing overlays/<< parameters.cluster >>/channels/azure-event updates
+          name: Committing overlays/<< parameters.cluster >>/channels updates
           working_directory: tmconfig/
           command: |
             git add overlays
-            git commit -m "Update overlays/<< parameters.cluster >>/channels/azure-event manifest to '${CIRCLE_TAG:-${CIRCLE_SHA1}}'"
+            git commit -m "Update overlays/<< parameters.cluster >>/channels azure-event deployment to '${CIRCLE_TAG:-${CIRCLE_SHA1}}'"
             git push origin << parameters.branch >>
 
   release:


### PR DESCRIPTION
- ci: switch to master only config updates 
- ci: remove dependence on .PATTERN file

depends on https://github.com/triggermesh/config/pull/130