### PR TITLE
ci: remove cloudbuild from build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ workflows:
           name: update-production-config
           cluster: prod
           requires:
-            - publish
+            - update-staging-config
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,6 @@ jobs:
       - run:
           name: Building package
           command: make build
-      - gcp-cli/install
-      - gcp-cli/initialize
-      - run:
-          name: Building docker image
-          command: make cloudbuild-test
 
   test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.1.1
-  gcp-cli: circleci/gcp-cli@1.8.4
+  go: circleci/go@1
+  gcp-cli: circleci/gcp-cli@1
 
 jobs:
   checkout:


### PR DESCRIPTION
- removed cloudbuilds from build job
- always use latest circleci orb versions
- serialize config updates