### PR TITLE
Kustomization base added

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- config/101-addressable-resolver-clusterrole.yaml
+- config/101-channelable-manipulator-clusterrole.yaml
+- config/101-roles.yaml
+- config/200-azure-channel.yaml
+- config/200-dispatcher-clusterrole.yaml
+- config/500-controller.yaml
+


### PR DESCRIPTION
As a part of deployment optimization described in [here](https://github.com/triggermesh/config/issues/516), this repository should act as a remote base for Kustomization. `kustomization.yaml` with deployment resources added to the repository root to keep `config` directory ko apply-able.